### PR TITLE
dry-run and minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 config.json
+config.hjson
 .env

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Install dependencies by running the following command in the root directory:
 
 ```bash
 $ npm i
+# or
+$ yarn install
 ```
 
 ### Configuration
@@ -56,7 +58,9 @@ $ npm i
 To run rewards for a given cycle:
 
 ```bash
-$ npm run pay --cycle=<cycle>
+$ npm run pay -- --cycle=<cycle>
+# or
+$ yarn pay -- --cycle=<cycle>
 ```
 
 ### Credits

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ import {
 } from "src/tezos-client";
 import { print_payments_table } from "src/cli";
 
-const config = parse(readFileSync("./config.hjson").toString());
+const config = parse(readFileSync(process.env.BC_CONFIG ?? "./config.hjson").toString());
 
 const paymentRequirements = [
   (p: BasePayment) => p.recipient !== config.baking_address,  // in case rewards are redirected to baker himself

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import { isNaN } from "lodash";
 import { program } from "commander";
 import { readFileSync } from "fs"
 import { parse } from "hjson"
@@ -7,23 +7,41 @@ import client from "src/api-client";
 import engine from "src/engine";
 
 import { initializeCycleReport } from "src/engine/helpers";
+import { BasePayment } from "src/engine/interfaces";
 import {
   createProvider,
   prepareTransaction,
   submitBatch,
 } from "src/tezos-client";
+import { print_payments_table } from "src/cli";
+
+const config = parse(readFileSync("./config.hjson").toString());
+
+const paymentRequirements = [
+  (p: BasePayment) => p.recipient !== config.baking_address,  // in case rewards are redirected to baker himself
+  (p: BasePayment) => !p.recipient.startsWith("KT"),           // TODO: we need to allow payments to smart contracts
+  (p: BasePayment) => p.amount.gt(0)                          // TODO: Add check for transaction fee
+]
+
+const arePaymentsRequirementsMet = (p: BasePayment) =>{
+  for (const requirement of paymentRequirements) {
+    if (!requirement(p)) return false
+  }
+  return true
+}
 
 const foo = async () => {
   program
     .requiredOption("-c, --cycle <number>", "specify the cycle to process")
+    .option("-d, --dry-run", "Prints out rewards. Won't sumbit transactions.")
     .parse();
 
   const opts = program.opts();
-  const config = parse(readFileSync("./config").toString());
+ 
 
   const cycle = Number(opts.cycle);
 
-  if (_.isNaN(cycle)) {
+  if (isNaN(cycle)) {
     throw Error("No cycle number given.");
   }
 
@@ -37,34 +55,18 @@ const foo = async () => {
     distributableRewards: cycleData.cycleRewards,
   });
 
-  const provider = createProvider();
   const { delegatorPayments, feeIncomePayments, bondRewardPayments } =
-    result.cycleReport;
-
-  const transactions = _.concat(
-    _.map(
-      _.reject(
-        delegatorPayments,
-        (p) => _.startsWith(p.recipient, "KT") || p.amount.eq(0)
-      ),
-      prepareTransaction
-    ),
-    _.map(
-      _.reject(
-        feeIncomePayments,
-        (p) => _.startsWith(p.recipient, "KT") || p.amount.eq(0)
-      ),
-      prepareTransaction
-    ),
-    _.map(
-      _.reject(
-        bondRewardPayments,
-        (p) => _.startsWith(p.recipient, "KT") || p.amount.eq(0)
-      ),
-      prepareTransaction
-    )
-  );
-
+  result.cycleReport;
+  
+  const allPayments = [ ...delegatorPayments, ...feeIncomePayments, ...bondRewardPayments ];
+  const transactions = allPayments.filter(arePaymentsRequirementsMet).map(prepareTransaction)
+  
+  if (opts.dryRun) {
+    print_payments_table(allPayments)
+    process.exit(0)
+  }
+  
+  const provider = createProvider();
   await submitBatch(provider, transactions);
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "pay": "ts-node index.ts --cycle $npm_config_cycle",
+    "pay": "ts-node index.ts",
     "configure": "ts-node src/config/configure.ts",
     "test": "jest --runInBand"
   },
@@ -21,6 +21,8 @@
     "axios": "^0.26.1",
     "bignumber.js": "^9.0.2",
     "commander": "^9.2.0",
+    "console-table-printer": "^2.11.0",
+    "dotenv": "^16.0.1",
     "hjson": "^3.2.2",
     "inquirer": "^8.2.2",
     "json-bigint": "^1.0.0",

--- a/src/api-client/abstract_client.ts
+++ b/src/api-client/abstract_client.ts
@@ -1,10 +1,10 @@
 import { BigNumber } from "bignumber.js";
 import { AxiosInstance } from "axios";
 
-export abstract class Client {
-  abstract instance: AxiosInstance;
-  abstract getCycleData(baker: string, cycle: number): Promise<CycleData>;
-  abstract getLastCycle(): Promise<number | void>;
+export interface Client {
+  instance: AxiosInstance;
+  getCycleData(baker: string, cycle: number): Promise<CycleData>;
+  getLastCycle(): Promise<number | void>;
 }
 
 export interface CycleData {

--- a/src/api-client/tzkt_client.ts
+++ b/src/api-client/tzkt_client.ts
@@ -5,11 +5,10 @@ import _ from "lodash";
 import { sum } from "../utils/math";
 import { Client, CycleData } from "./abstract_client";
 
-export class TzKT extends Client {
+export class TzKT implements Client {
   instance: AxiosInstance;
 
   constructor() {
-    super();
     this.instance = axios.create({
       baseURL: "https://api.tzkt.io/v1/",
       transformResponse: [JSONBigInt.parse],

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,20 @@
+import { Table } from "console-table-printer";
+import { BasePayment } from "src/engine/interfaces";
+import { pick } from "lodash"
+import { MUTEZ_FACTOR } from "src/utils/constants";
+import { divide } from "src/utils/math";
+import { PrintablePayment } from "./interfaces";
+
+export const print_payments_table = (payments: BasePayment[]) => {
+	const table = new Table();
+	const columns = ["delegator", "recipient", "delegatorBalance", "amount", "feeRate"]
+	table.addColumns(columns)
+	for (const payment of payments) {
+		const paymentInfo: Partial<PrintablePayment> = pick(payment, columns)
+
+		paymentInfo.amount = `${divide(paymentInfo.amount ?? 0, MUTEZ_FACTOR)} TEZ`
+		paymentInfo.delegatorBalance = `${divide(paymentInfo.delegatorBalance ?? 0, MUTEZ_FACTOR)} TEZ`
+		table.addRow(paymentInfo)
+	}
+	table.printTable()
+}

--- a/src/cli/interfaces.ts
+++ b/src/cli/interfaces.ts
@@ -1,0 +1,9 @@
+import BigNumber from "bignumber.js";
+
+export interface PrintablePayment {
+	cycle: number;
+	recipient: string;
+	amount: BigNumber | string;
+	delegatorBalance: BigNumber | string;
+	hash: string;
+}

--- a/src/engine/helpers.ts
+++ b/src/engine/helpers.ts
@@ -1,15 +1,16 @@
 import { BigNumber } from "bignumber.js";
 import { Config } from "src/config";
 import { CycleReport } from "./interfaces";
+import { get } from "lodash"
 
 export const getApplicableFee = (config: Config, delegator: string) => {
   return new BigNumber(
-    config.fee_exceptions[delegator] || config.default_fee
+    get(config.fee_exceptions, delegator, config.default_fee)
   ).div(100);
 };
 
 export const getRedirectAddress = (config: Config, delegator: string) => {
-  return config.redirect_payments[delegator] || delegator;
+  return get(config.redirect_payments, delegator, delegator);
 };
 
 export const isOverDelegated = (

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const MUTEZ_FACTOR = 1000000;


### PR DESCRIPTION
## Overview

Added `dry-run` and other minor improvements

## Changes

  - added --dry-run - prints table of payments
  - fixed missing dotenv dependency in package.json
  - added yarn commands into readme
  - changed pay command in package.json so we can pass arguments directly
  - abstract client changed to interface
  - fixed config.hjson load path
  - accept BC_CONFIG as reference to config file
  
  ## Usage
  
```sh
npm run pay -- --cycle=480 --dry-run
# or 
yarn pay -- --cycle=480 --dry-run
```