### PR TITLE
bugfix: handle zero-rewards

### DIFF
--- a/src/cli/cmd/pay.ts
+++ b/src/cli/cmd/pay.ts
@@ -90,11 +90,15 @@ export const pay = async (commandOptions) => {
   }
 
   if (globalCliOptions.dryRun) {
+    if (isEmpty(batches) || every(batches, (batch) => isEmpty(batch))) {
+      console.log("There is noting to pay for this cycle.");
+    }
     if (result.flags?.insufficientBalance) {
       console.log(
         "NOTE: Balance is insufficient. Transaction fees not estimated."
       );
     }
+
     process.exit(0);
   }
 

--- a/src/engine/steps/resolveBondRewardDistribution.ts
+++ b/src/engine/steps/resolveBondRewardDistribution.ts
@@ -5,7 +5,7 @@ import {
   StepArguments,
 } from "src/engine/interfaces";
 import { divide, multiply, integerize } from "src/utils/math";
-import { paymentAmountRequirementsFactory } from "../validate";
+import { paymentAmountAboveZeroFactory } from "../validate";
 
 export const resolveBondRewardDistribution = (
   args: StepArguments
@@ -40,10 +40,7 @@ export const resolveBondRewardDistribution = (
     }
 
     /* Sanity check */
-    const bondRewardPayments = filter(
-      payments,
-      paymentAmountRequirementsFactory
-    );
+    const bondRewardPayments = filter(payments, paymentAmountAboveZeroFactory);
 
     return {
       ...args,

--- a/src/engine/steps/resolveEstimateTransactionFees.ts
+++ b/src/engine/steps/resolveEstimateTransactionFees.ts
@@ -1,4 +1,4 @@
-import { get, last, map } from "lodash";
+import { get, isEmpty, last, map } from "lodash";
 import { ParamsWithKind } from "@taquito/taquito";
 import BigNumber from "bignumber.js";
 
@@ -30,9 +30,11 @@ export const resolveEstimateTransactionFees = async (
   );
 
   try {
-    const walletEstimates = await tezos.estimate.batch(
-      map(walletPayments, prepareTransaction) as ParamsWithKind[]
-    );
+    const walletEstimates = isEmpty(walletPayments)
+      ? []
+      : await tezos.estimate.batch(
+          map(walletPayments, prepareTransaction) as ParamsWithKind[]
+        );
     if (walletEstimates.length - 1 === walletPayments.length) {
       /* Exclude reveal operation at the beginning. This only happens on testnet */
       walletEstimates.splice(0, 1);

--- a/src/engine/steps/resolveExcludedPaymentsByContext.ts
+++ b/src/engine/steps/resolveExcludedPaymentsByContext.ts
@@ -1,6 +1,6 @@
 import { StepArguments } from "src/engine/interfaces";
 import {
-  paymentAmountRequirementsFactory,
+  paymentAmountAboveZeroFactory,
   paymentContextRequirementsFactory,
 } from "src/engine/validate";
 
@@ -11,7 +11,7 @@ export const resolveExcludedPaymentsByContext = (
 
   const delegatorPayments = cycleReport.delegatorPayments
     .filter(paymentContextRequirementsFactory(config))
-    .filter(paymentAmountRequirementsFactory);
+    .filter(paymentAmountAboveZeroFactory);
 
   return {
     ...args,

--- a/src/engine/steps/resolveExcludedPaymentsByContext.ts
+++ b/src/engine/steps/resolveExcludedPaymentsByContext.ts
@@ -1,14 +1,17 @@
 import { StepArguments } from "src/engine/interfaces";
-import { paymentContextRequirementsFactory } from "src/engine/validate";
+import {
+  paymentAmountRequirementsFactory,
+  paymentContextRequirementsFactory,
+} from "src/engine/validate";
 
 export const resolveExcludedPaymentsByContext = (
   args: StepArguments
 ): StepArguments => {
   const { cycleReport, config } = args;
 
-  const delegatorPayments = cycleReport.delegatorPayments.filter(
-    paymentContextRequirementsFactory(config)
-  );
+  const delegatorPayments = cycleReport.delegatorPayments
+    .filter(paymentContextRequirementsFactory(config))
+    .filter(paymentAmountRequirementsFactory);
 
   return {
     ...args,

--- a/src/engine/steps/resolveFeeIncomeDistribution.ts
+++ b/src/engine/steps/resolveFeeIncomeDistribution.ts
@@ -5,7 +5,7 @@ import {
   StepArguments,
 } from "src/engine/interfaces";
 import { divide, multiply, integerize } from "src/utils/math";
-import { paymentAmountRequirementsFactory } from "../validate";
+import { paymentAmountAboveZeroFactory } from "../validate";
 
 export const resolveFeeIncomeDistribution = (
   args: StepArguments
@@ -40,10 +40,7 @@ export const resolveFeeIncomeDistribution = (
     }
 
     /* Sanity check */
-    const feeIncomePayments = filter(
-      payments,
-      paymentAmountRequirementsFactory
-    );
+    const feeIncomePayments = filter(payments, paymentAmountAboveZeroFactory);
 
     return {
       ...args,

--- a/src/engine/steps/resolveSplitIntoBatches.ts
+++ b/src/engine/steps/resolveSplitIntoBatches.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { isEmpty } from "lodash";
 
 import { BasePayment, StepArguments } from "src/engine/interfaces";
-import { paymentAmountRequirementsFactory } from "src/engine/validate";
+import { paymentAmountAboveZeroFactory } from "src/engine/validate";
 import { add } from "src/utils/math";
 
 export const resolveSplitIntoBatches = async (
@@ -35,7 +35,7 @@ export const resolveSplitIntoBatches = async (
   const { delegatorPayments } = cycleReport;
 
   const filteredDelegatorPayments = delegatorPayments.filter(
-    paymentAmountRequirementsFactory
+    paymentAmountAboveZeroFactory
   );
 
   for (const payment of filteredDelegatorPayments) {

--- a/src/engine/validate.ts
+++ b/src/engine/validate.ts
@@ -15,7 +15,7 @@ const paymentContextRequirements = (
   ];
 };
 
-const paymentAmountRequirements: Validator[] = [
+const paymentAmountAboveZero: Validator[] = [
   (p: BasePayment) => p.amount.gt(0),
 ];
 
@@ -32,8 +32,8 @@ const arePaymentsRequirementsMet = (
 const requirementsFactory = (requirements: Validator[]) => (p: BasePayment) =>
   arePaymentsRequirementsMet(p, requirements);
 
-export const paymentAmountRequirementsFactory = requirementsFactory(
-  paymentAmountRequirements
+export const paymentAmountAboveZeroFactory = requirementsFactory(
+  paymentAmountAboveZero
 );
 
 export const paymentContextRequirementsFactory = (config) =>


### PR DESCRIPTION
## Issue 
 
NA

## Overview

Fixes flow for edge case where baker has zero rewards in a cycle

## Changes


- Upstream filtering of zero transactions
- Do not estimate fees for batch if batch is empty
- Informative logging.

## Usage and Testing

