### PR TITLE
fix: include fee estimate in transaction

### DIFF
--- a/src/cli/cmd/pay.ts
+++ b/src/cli/cmd/pay.ts
@@ -12,7 +12,7 @@ import {
 } from "src/cli/print";
 import {
   createProvider,
-  prepareTransaction,
+  prepareTransactionForSubmission,
   sendBatch,
 } from "src/tezos-client";
 import { globalCliOptions } from "src/cli/global";
@@ -146,7 +146,10 @@ export const pay = async (commandOptions) => {
           nonEmptyBatches[i].length
         } transaction(s) ...`
       );
-      const opBatch = await sendBatch(provider, batch.map(prepareTransaction));
+      const opBatch = await sendBatch(
+        provider,
+        batch.map(prepareTransactionForSubmission)
+      );
       for (const payment of batch) {
         payment.hash = opBatch.opHash;
       }

--- a/src/engine/steps/resolveEstimateTransactionFees.ts
+++ b/src/engine/steps/resolveEstimateTransactionFees.ts
@@ -2,7 +2,7 @@ import { get, isEmpty, last, map } from "lodash";
 import { ParamsWithKind } from "@taquito/taquito";
 import BigNumber from "bignumber.js";
 
-import { prepareTransaction } from "src/tezos-client";
+import { prepareTransactionForEstimation } from "src/tezos-client";
 import { ENoteType, StepArguments } from "src/engine/interfaces";
 import { add } from "src/utils/math";
 
@@ -33,7 +33,10 @@ export const resolveEstimateTransactionFees = async (
     const walletEstimates = isEmpty(walletPayments)
       ? []
       : await tezos.estimate.batch(
-          map(walletPayments, prepareTransaction) as ParamsWithKind[]
+          map(
+            walletPayments,
+            prepareTransactionForEstimation
+          ) as ParamsWithKind[]
         );
     if (walletEstimates.length - 1 === walletPayments.length) {
       /* Exclude reveal operation at the beginning. This only happens on testnet */
@@ -75,7 +78,7 @@ export const resolveEstimateTransactionFees = async (
       /* last to skip reveal operation at the beginning. This only happens on testnet */
       const estimate = last(
         await tezos.estimate.batch([
-          prepareTransaction(payment),
+          prepareTransactionForEstimation(payment),
         ] as ParamsWithKind[])
       );
       if (!estimate)

--- a/src/tezos-client/index.ts
+++ b/src/tezos-client/index.ts
@@ -33,20 +33,10 @@ export const prepareTransactionForSubmission = (
     to: payment.recipient,
     amount: payment.amount.toNumber(),
     mutez: true,
-    /* For current simplicity, submit non-delegator payments without the estimates */
-    fee:
-      payment.type === EPaymentType.Delegator
-        ? payment.transactionFee?.toNumber()
-        : undefined,
-
-    gasLimit:
-      payment.type === EPaymentType.Delegator
-        ? payment.gasLimit?.toNumber()
-        : undefined,
-    storageLimit:
-      payment.type === EPaymentType.Delegator
-        ? payment.storageLimit?.toNumber()
-        : undefined,
+    /* Payments can pass through without an estimate – e.g. non-delegator payments. */
+    fee: payment.transactionFee?.toNumber(),
+    gasLimit: payment.gasLimit?.toNumber(),
+    storageLimit: payment.storageLimit?.toNumber(),
   };
 };
 

--- a/src/tezos-client/index.ts
+++ b/src/tezos-client/index.ts
@@ -3,7 +3,7 @@
 import { OpKind, TezosToolkit, WalletParamsWithKind } from "@taquito/taquito";
 import { BatchWalletOperation } from "@taquito/taquito/dist/types/wallet/batch-operation";
 import { BreadcrumbsConfiguration } from "src/config/interfaces";
-import { BasePayment } from "src/engine/interfaces";
+import { BasePayment, EPaymentType } from "src/engine/interfaces";
 import { getSigner } from "src/tezos-client/signers";
 
 export const createProvider = async (config: BreadcrumbsConfiguration) => {
@@ -14,7 +14,7 @@ export const createProvider = async (config: BreadcrumbsConfiguration) => {
   return tezos;
 };
 
-export const prepareTransaction = (
+export const prepareTransactionForEstimation = (
   payment: BasePayment
 ): WalletParamsWithKind => {
   return {
@@ -22,6 +22,31 @@ export const prepareTransaction = (
     to: payment.recipient,
     amount: payment.amount.toNumber(),
     mutez: true,
+  };
+};
+
+export const prepareTransactionForSubmission = (
+  payment: BasePayment
+): WalletParamsWithKind => {
+  return {
+    kind: OpKind.TRANSACTION,
+    to: payment.recipient,
+    amount: payment.amount.toNumber(),
+    mutez: true,
+    /* For current simplicity, submit non-delegator payments without the estimates */
+    fee:
+      payment.type === EPaymentType.Delegator
+        ? payment.transactionFee?.toNumber()
+        : undefined,
+
+    gasLimit:
+      payment.type === EPaymentType.Delegator
+        ? payment.gasLimit?.toNumber()
+        : undefined,
+    storageLimit:
+      payment.type === EPaymentType.Delegator
+        ? payment.storageLimit?.toNumber()
+        : undefined,
   };
 };
 


### PR DESCRIPTION
## Issue 
 
Not created

## Overview

Usage by our first tester has demonstrated that payout amounts had a slight variance with the expectation of baking-bad.org

This was related to the fact that fee estimates were not actually submitted with the transaction.

## Changes

Include fee estimates in transactions at batch submission. 

## Usage and Testing

N/A