### PR TITLE
Trim loaded wallet private key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "breadcrumbs",
-  "version": "0.0.4-alpha",
+  "version": "0.0.5-alpha",
   "description": "",
   "main": "index.js",
   "targets": {

--- a/src/tezos-client/signers/in-memory.ts
+++ b/src/tezos-client/signers/in-memory.ts
@@ -7,7 +7,9 @@ import { WALLET_PRIVATE_KEY_FILE } from "src/utils/constants";
 export const loadStoredPrivateKey = async () => {
   return (
     await readFile(join(globalCliOptions.workDir, WALLET_PRIVATE_KEY_FILE))
-  ).toString();
+  )
+    .toString()
+    .trim();
 };
 
 export const getInMemorySigner = async (key?: string) => {


### PR DESCRIPTION
Fixes issue when users add newline/whitespace characters at the end of `payout_wallet_private.key` file.

Fixes #42 