### PR TITLE
fix: unnecessary Telegram notifications

### DIFF
--- a/src/plugin/notification/telegram/client.ts
+++ b/src/plugin/notification/telegram/client.ts
@@ -1,3 +1,5 @@
+process.env["NTBA_FIX_319"] = "1";
+
 import TelegramBot from "node-telegram-bot-api";
 import {
   NotificationPlugin,


### PR DESCRIPTION
## Issue 
 
Getting unnecessary Telegram bot notifications: 

```
node-telegram-bot-api deprecated Automatic enabling of cancellation of promises is deprecated.
In the future, you will have to enable it yourself.
See https://github.com/yagop/node-telegram-bot-api/issues/319. 

```
## Overview

Fix as per recommended method. 

## Changes

Add process.env["NTBA_FIX_319"] = "1" to Telegram client.ts file. 

## Usage and Testing

Tested payouts on testnet