### PR TITLE
accept http rpc url

### DIFF
--- a/src/config/validate/runtime.ts
+++ b/src/config/validate/runtime.ts
@@ -41,7 +41,7 @@ const validDistributionShares = Joi.custom((i) => {
   }
 });
 
-const validRpcUrl = Joi.string().uri({ scheme: ["https"] });
+const validRpcUrl = Joi.string().uri({ scheme: ["https", "http"] });
 
 const validPlugin = Joi.object({
   type: Joi.string()

--- a/test/config/validate/runtime.test.ts
+++ b/test/config/validate/runtime.test.ts
@@ -78,7 +78,7 @@ describe("configuration validation (runtime)", () => {
     }
   });
   test("does not accept an invalid RPC URL", () => {
-    const invalidValues = ["http://ghostnet.ecadinfra.com", true, 1, "foo.bar"];
+    const invalidValues = ["tcp://ghostnet.ecadinfra.com", true, 1, "foo.bar"];
 
     for (const v of invalidValues) {
       const input = { ...baseConfig, network_configuration: { rpc_url: v } };


### PR DESCRIPTION
It is possible to run rewards distributor on the same machine that runs the tezos node.

Or, like in my case, in a k8s service in the same cluster. In this case, http is fine.